### PR TITLE
CI設定変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,15 @@
 version: 2
 jobs:
+
   build:
+    docker:
+      - image: cimg/node:16.5.0
+    steps:
+        - checkout
+        - run:
+            name: node --version
+
+  test:
     docker:
       - image: circleci/php:7.3.0-node-browsers
       - image: circleci/mariadb:10.4
@@ -58,4 +67,13 @@ jobs:
       - run:
           name: Run PHPUnit 
           command: koyolympus/vendor/bin/phpunit koyolympus/tests/Unit/
+
+workflows:
+    version: 2
+    builad_and_test:
+      jobs:
+       - build
+       - test:
+           requires:
+             - build
 


### PR DESCRIPTION
Circle CIにnode, npmを使ったビルド・テストカバレッジ取得、デプロイ作業を追加する。

ビルド、テスト、カバレッジ取得は、全ブランチを対象に行う。
デプロイに関しては、masterから新しいtagが切られた場合にのみ、行われる。